### PR TITLE
修复Redis打开RDB文件提示：/etc  Permission denied

### DIFF
--- a/services/redis/redis.conf
+++ b/services/redis/redis.conf
@@ -260,7 +260,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir ./
+dir /data
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
 Failed opening the RDB file crontab (in server root dir /etc) for saving: Permission denied